### PR TITLE
fix: missing read-lock

### DIFF
--- a/erm/templates/contentful_vo_lib.gotmpl
+++ b/erm/templates/contentful_vo_lib.gotmpl
@@ -695,7 +695,9 @@ func (cc *ContentfulClient) syncCache(ctx context.Context, contentTypes []string
 				}
 				updateCacheForContentTypeAndEntity(ctx, cc, entry.Sys.ContentType.Sys.ID, entry.Sys.ID, entry, false)
 			case sysTypeDeletedEntry:
+				cc.Cache.idContentTypeMapGcLock.RLock()
 				contentType := cc.Cache.idContentTypeMap[entry.Sys.ID]
+				cc.Cache.idContentTypeMapGcLock.RUnlock()
 				updateCacheForContentTypeAndEntity(ctx, cc, contentType, entry.Sys.ID, entry, true)
 			default:
 			}


### PR DESCRIPTION
Should fix a concurrent map access error.

`fatal error: concurrent map read and map write

goroutine 1289 [running]:
github.com/bestbytes/galeria/pkg/contentful/site.(*ContentfulClient).syncCache(0xc0002c33b0, {0x22e3658, 0xc3ce54ff80}, {0x30cb440, 0x29, 0x29})
	github.com/bestbytes/galeria/pkg@v0.0.0/contentful/site/gocontentfulvolib.go:1322 +0xa5e
github.com/bestbytes/galeria/pkg/contentful/site.(*ContentfulClient).UpdateCache(0xc0002c33b0, {0x22e3620, 0xc00022a000}, {0x30cb440, 0x29, 0x29}, 0x0)
	github.com/bestbytes/galeria/pkg@v0.0.0/contentful/site/gocontentfulvolib.go:1240 +0x80c
github.com/bestbytes/galeria/catalogue/packages/services/catalogue.(*Service).categoryDirectoryUpdateLoop(0xc00910e580, {0x22e3620, 0xc00022a000}, 0xc765ea7140, 0x0?, 0xc0090b8340)
	github.com/bestbytes/galeria/catalogue/packages/services/catalogue/categorydirectoryupdater.go:45 +0x21b
created by github.com/bestbytes/galeria/catalogue/packages/services/catalogue.(*Service).getCategoryDirectoryUpdateFunc
	github.com/bestbytes/galeria/catalogue/packages/services/catalogue/categorydirectoryupdater.go:20 +0xfa`