### PR TITLE
fix: optimisticPageSizeGetAll needs to consider the "Too many links" hard limit on the CDA and CPA APIs

### DIFF
--- a/erm/templates/contentful_vo_lib.gotmpl
+++ b/erm/templates/contentful_vo_lib.gotmpl
@@ -1985,7 +1985,7 @@ func (cc *ContentfulClient) optimisticPageSizeGetAll(ctx context.Context, conten
 	switch errTyped := err.(type) {
 	case contentful.ErrorResponse:
 		msg := errTyped.Message
-		if strings.Contains(msg, "Response size too big") && limit >= 20 {
+		if (strings.Contains(msg, "Response size too big") || strings.Contains(msg, "Too many links")) && limit >= 20 {
 			smallerPageCol, err := cc.optimisticPageSizeGetAll(ctx, contentType, limit/2)
 			return smallerPageCol, err
 		}


### PR DESCRIPTION
Client runs into hard limits if there are more than 10000 entries in one response ...