### PR TITLE
fix: Client runs into hard error when the size of 10 elements exceeds Contenful's limit

### DIFF
--- a/erm/templates/contentful_vo_lib_contenttype.gotmpl
+++ b/erm/templates/contentful_vo_lib_contenttype.gotmpl
@@ -657,7 +657,7 @@ func (cc *ContentfulClient) optimisticPageSizeGetAll{{ firstCap $contentType.Sys
 	switch errTyped := err.(type) {
 	case contentful.ErrorResponse:
 		msg := errTyped.Message
-		if (strings.Contains(msg, "Response size too big") || strings.Contains(msg, "Too many links")) && limit >= 20 {
+		if (strings.Contains(msg, "Response size too big") || strings.Contains(msg, "Too many links")) && limit >= 2 {
 			smallerPageCol, err := cc.optimisticPageSizeGetAll{{ firstCap $contentType.Sys.ID }}(ctx, contentType, limit/2)
 			return smallerPageCol, err
 		}

--- a/test/testapi/gocontentfulvolibbrand.go
+++ b/test/testapi/gocontentfulvolibbrand.go
@@ -745,7 +745,7 @@ func (cc *ContentfulClient) optimisticPageSizeGetAllBrand(ctx context.Context, c
 	switch errTyped := err.(type) {
 	case contentful.ErrorResponse:
 		msg := errTyped.Message
-		if (strings.Contains(msg, "Response size too big") || strings.Contains(msg, "Too many links")) && limit >= 20 {
+		if (strings.Contains(msg, "Response size too big") || strings.Contains(msg, "Too many links")) && limit >= 2 {
 			smallerPageCol, err := cc.optimisticPageSizeGetAllBrand(ctx, contentType, limit/2)
 			return smallerPageCol, err
 		}

--- a/test/testapi/gocontentfulvolibcategory.go
+++ b/test/testapi/gocontentfulvolibcategory.go
@@ -509,7 +509,7 @@ func (cc *ContentfulClient) optimisticPageSizeGetAllCategory(ctx context.Context
 	switch errTyped := err.(type) {
 	case contentful.ErrorResponse:
 		msg := errTyped.Message
-		if (strings.Contains(msg, "Response size too big") || strings.Contains(msg, "Too many links")) && limit >= 20 {
+		if (strings.Contains(msg, "Response size too big") || strings.Contains(msg, "Too many links")) && limit >= 2 {
 			smallerPageCol, err := cc.optimisticPageSizeGetAllCategory(ctx, contentType, limit/2)
 			return smallerPageCol, err
 		}

--- a/test/testapi/gocontentfulvolibproduct.go
+++ b/test/testapi/gocontentfulvolibproduct.go
@@ -1347,7 +1347,7 @@ func (cc *ContentfulClient) optimisticPageSizeGetAllProduct(ctx context.Context,
 	switch errTyped := err.(type) {
 	case contentful.ErrorResponse:
 		msg := errTyped.Message
-		if (strings.Contains(msg, "Response size too big") || strings.Contains(msg, "Too many links")) && limit >= 20 {
+		if (strings.Contains(msg, "Response size too big") || strings.Contains(msg, "Too many links")) && limit >= 2 {
 			smallerPageCol, err := cc.optimisticPageSizeGetAllProduct(ctx, contentType, limit/2)
 			return smallerPageCol, err
 		}


### PR DESCRIPTION
### Description

If the size for 10 elements is > 7340032B, the client runs into a hard error. It should ideally continue subdividing the page limit until it reachs 1 per page if needed.
`updateCacheForContentType failed for contentType [contentTypeName]: optimisticPageSizeGetAll for [ContentTypeName] failed:`
```json
{
    "message": "Response size too big. Maximum allowed response size: 7340032B.",
    "sys":
    {
        "id": "BadRequest",
        "type": "Error"
    }
}
```

### Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Tests
- [ ] 🔧 Build/CI

### Related Issue

None

## Changes

- Update min page size when getting content elements from contenful to 1 instead of 10

### Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.

#### Notes

I ran `make testapi`, not sure if anything else is needed.
