### PR TITLE
feat: add region support to config, generator, templates and testapi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,11 @@ lint.fix:
 testapi:
 	@go run ./main.go -exportfile ./test/test-space-export.json ./test/testapi
 
+.PHONY: testapi-region
+## run api tests with EU region
+testapi-region:
+	@go run ./main.go -exportfile ./test/test-space-export.json -region eu ./test/testapi
+
 .PHONY: test
 ## Run tests
 test: testapi

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,16 +1,34 @@
 package config
 
 import (
+	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestConfigFromYAML(t *testing.T) {
-	config, err := LoadConfigFromYAML("./sampleconfig.yaml")
-	require.NoError(t, err)
-	require.Equal(t, "abc123", config.SpaceID)
-	require.Equal(t, "dev", config.Environment)
-	require.Equal(t, "v1.0.19", config.RequireVersion)
-	require.Len(t, config.ContentTypes, 2)
+func TestLoadConfigFromYAML(t *testing.T) {
+	t.Run("full config with region", func(t *testing.T) {
+		cfg, err := LoadConfigFromYAML("./sampleconfig.yaml")
+		require.NoError(t, err)
+		require.Equal(t, "abc123", cfg.SpaceID)
+		require.Equal(t, "dev", cfg.Environment)
+		require.Equal(t, "v1.0.19", cfg.RequireVersion)
+		require.Len(t, cfg.ContentTypes, 2)
+		assert.Equal(t, "eu", cfg.Region)
+	})
+	t.Run("region defaults to empty string when absent", func(t *testing.T) {
+		f, err := os.CreateTemp("", "gocontentful-test-*.yaml")
+		require.NoError(t, err)
+		defer os.Remove(f.Name())
+		_, err = f.WriteString("spaceId: abc123\n")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		cfg, err := LoadConfigFromYAML(f.Name())
+		require.NoError(t, err)
+		require.Equal(t, "abc123", cfg.SpaceID)
+		assert.Equal(t, "", cfg.Region)
+	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,9 +19,8 @@ func TestLoadConfigFromYAML(t *testing.T) {
 		assert.Equal(t, "eu", cfg.Region)
 	})
 	t.Run("region defaults to empty string when absent", func(t *testing.T) {
-		f, err := os.CreateTemp("", "gocontentful-test-*.yaml")
+		f, err := os.CreateTemp(t.TempDir(), "gocontentful-test-*.yaml")
 		require.NoError(t, err)
-		defer os.Remove(f.Name())
 		_, err = f.WriteString("spaceId: abc123\n")
 		require.NoError(t, err)
 		require.NoError(t, f.Close())

--- a/config/sampleconfig.yaml
+++ b/config/sampleconfig.yaml
@@ -1,3 +1,4 @@
+region: eu
 spaceId: "abc123"
 environment: "dev"
 exportFile: "foo.json"

--- a/config/vo.go
+++ b/config/vo.go
@@ -7,4 +7,5 @@ type Config struct {
 	ContentTypes      []string `json:"contentTypes,omitempty" yaml:"contentTypes,omitempty"`
 	PathTargetPackage string   `json:"pathTargetPackage,omitempty" yaml:"pathTargetPackage,omitempty"`
 	RequireVersion    string   `json:"requireVersion,omitempty" yaml:"requireVersion,omitempty"`
+	Region            string   `json:"region,omitempty" yaml:"region,omitempty"`
 }

--- a/erm/space.go
+++ b/erm/space.go
@@ -25,6 +25,7 @@ type spaceConf struct {
 	ContentTypes []ContentType          `yaml:"contentTypes"`
 	ContentType  ContentType            `yaml:"contentType"`
 	Version      string                 `yaml:"version"`
+	Region       string                 `yaml:"region"`
 }
 
 // GetLocales retrieves locale definition from Contentful
@@ -82,7 +83,7 @@ func getContentTypes(ctx context.Context, cma *contentful.Contentful, spaceID st
 	return
 }
 
-func getData(ctx context.Context, spaceID, cmaKey, environment, exportFile string, flagContentTypes []string) (
+func getData(ctx context.Context, spaceID, cmaKey, environment, exportFile string, flagContentTypes []string, region string) (
 	finalContentTypes []ContentType, locales []Locale, err error,
 ) {
 	var contentTypes []ContentType
@@ -100,7 +101,7 @@ func getData(ctx context.Context, spaceID, cmaKey, environment, exportFile strin
 		locales = export.Locales
 	} else {
 		// Get client
-		CMA := contentful.NewCMA(cmaKey)
+		CMA := contentful.NewCMA(cmaKey).SetRegion(contentful.Region(region))
 		CMA.Debug = false
 		if environment != "" {
 			CMA.Environment = environment
@@ -141,8 +142,11 @@ func getData(ctx context.Context, spaceID, cmaKey, environment, exportFile strin
 }
 
 // GenerateAPI calls the generators
-func GenerateAPI(ctx context.Context, dir, packageName, spaceID, cmaKey, environment, exportFile string, flagContentTypes []string, version string) error {
-	contentTypes, locales, errGetData := getData(ctx, spaceID, cmaKey, environment, exportFile, flagContentTypes)
+func GenerateAPI(ctx context.Context, dir, packageName, spaceID, cmaKey, environment, exportFile string, flagContentTypes []string, version string, region string) error {
+	if _, err := contentful.ParseRegion(region); err != nil {
+		return err
+	}
+	contentTypes, locales, errGetData := getData(ctx, spaceID, cmaKey, environment, exportFile, flagContentTypes, region)
 	if errGetData != nil {
 		return errors.Wrap(errGetData, "could not get data")
 	}
@@ -160,6 +164,7 @@ func GenerateAPI(ctx context.Context, dir, packageName, spaceID, cmaKey, environ
 		Locales:      locales,
 		ContentTypes: contentTypes,
 		Version:      version,
+		Region:       region,
 	}
 	return generateCode(conf)
 }

--- a/erm/space_test.go
+++ b/erm/space_test.go
@@ -1,0 +1,44 @@
+package erm
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testExportFile = "../test/test-space-export.json"
+
+func TestGenerateAPI_EmbedRegionEU(t *testing.T) {
+	dir := t.TempDir()
+	err := GenerateAPI(context.Background(), dir, "testpkg", "", "", "", testExportFile, nil, "test", "eu")
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(dir, "testpkg", "gocontentfulvolib.go"))
+	require.NoError(t, err)
+
+	src := string(content)
+	assert.True(t, strings.Contains(src, `.SetRegion("eu")`), "generated lib should call SetRegion(\"eu\")")
+}
+
+func TestGenerateAPI_InvalidRegion(t *testing.T) {
+	err := GenerateAPI(context.Background(), t.TempDir(), "testpkg", "", "", "", testExportFile, nil, "test", "ap")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "unknown region")
+}
+
+func TestGenerateAPI_EmbedRegionEmpty(t *testing.T) {
+	dir := t.TempDir()
+	err := GenerateAPI(context.Background(), dir, "testpkg", "", "", "", testExportFile, nil, "test", "")
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(dir, "testpkg", "gocontentfulvolib.go"))
+	require.NoError(t, err)
+
+	src := string(content)
+	assert.False(t, strings.Contains(src, `.SetRegion(`), "generated lib should not call SetRegion for default region")
+}

--- a/erm/templates/contentful_vo_lib.gotmpl
+++ b/erm/templates/contentful_vo_lib.gotmpl
@@ -751,7 +751,7 @@ func NewOfflineContentfulClient(file []byte, logFn func(fields map[string]interf
 	}
 	cc := &ContentfulClient{
 		clientMode:  ClientModeCDA,
-		Client:      contentful.NewCDA(""),
+		Client:      contentful.NewCDA(""){{ if .Region }}.SetRegion("{{ .Region }}"){{ end }},
 		Cache: &ContentfulCache{
             contentTypes:     []string{},
             idContentTypeMap: map[string]string{},
@@ -1864,16 +1864,19 @@ func (cc *ContentfulClient) entryMapForContentTypeIsNil(contentType string) bool
 }
 
 func getContentfulAPIClient(clientMode ClientMode, clientKey string) (*contentful.Contentful, error) {
+	var c *contentful.Contentful
 	switch clientMode {
 	case ClientModeCDA:
-		return contentful.NewCDA(clientKey), nil
+		c = contentful.NewCDA(clientKey)
 	case ClientModeCPA:
-		return contentful.NewCPA(clientKey), nil
+		c = contentful.NewCPA(clientKey)
 	case ClientModeCMA:
-		return contentful.NewCMA(clientKey), nil
+		c = contentful.NewCMA(clientKey)
 	default:
 		return nil, errors.New("NewContentfulClient: Unknown ClientMode")
 	}
+	{{ if .Region }}c.SetRegion("{{ .Region }}")
+	{{ end }}return c, nil
 }
 
 func (cc *ContentfulClient) GetSpaceID() string {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/foomo/gocontentful
 go 1.24.0
 
 require (
-	github.com/foomo/contentful v0.6.0
+	github.com/foomo/contentful v0.6.3
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/aoliveti/curling v1.1.0/go.mod h1:xoDmoUg9vX3pMTltyG/rp9tFtIlweL2QeCJ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/foomo/contentful v0.6.0 h1:k9VOQj1ZxSbl5HR2oBvunNeuqTW9U48yAz6jYeDxYdE=
-github.com/foomo/contentful v0.6.0/go.mod h1:xJ09xn+hTb5RKFyYL8vscxBh+DSH1wRzOljc9paEpp8=
+github.com/foomo/contentful v0.6.3 h1:KlP4nYeV4Y3YlffYaz6t6xJ8CpF8ce/yA70j41YyOAY=
+github.com/foomo/contentful v0.6.3/go.mod h1:xJ09xn+hTb5RKFyYL8vscxBh+DSH1wRzOljc9paEpp8=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=

--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ func main() {
 	flagEnvironment := flag.String("environment", "", "[Optional] Contentful space environment")
 	flagGenerateFromExport := flag.String("exportfile", "", "Space export file to generate the API from")
 	flagContentTypes := flag.String("contenttypes", "", "[Optional] Content type IDs to parse, comma separated")
+	flagRegion := flag.String("region", "", "[Optional] Contentful infrastructure region (e.g. eu)")
 	flagVersion := flag.Bool("version", false, "Print version and exit")
 	flagHelp := flag.Bool("help", false, "Print version and exit")
 	flag.Parse()
@@ -95,6 +96,7 @@ func main() {
 			SpaceID:     *flagSpaceID,
 			Environment: *flagEnvironment,
 			ExportFile:  *flagGenerateFromExport,
+			Region:      *flagRegion,
 		}
 		if *flagContentTypes != "" {
 			conf.ContentTypes = strings.Split(*flagContentTypes, ",")
@@ -140,7 +142,7 @@ func main() {
 		}
 	}
 
-	err = erm.GenerateAPI(context.Background(), filepath.Dir(path), packageName, conf.SpaceID, cmaKey, conf.Environment, conf.ExportFile, cleanContentTypes, VERSION)
+	err = erm.GenerateAPI(context.Background(), filepath.Dir(path), packageName, conf.SpaceID, cmaKey, conf.Environment, conf.ExportFile, cleanContentTypes, VERSION, conf.Region)
 	if err != nil {
 		fatal("Something went horribly wrong...", err)
 	}

--- a/test/testapi/gocontentfulvolib.go
+++ b/test/testapi/gocontentfulvolib.go
@@ -1898,16 +1898,18 @@ func (cc *ContentfulClient) entryMapForContentTypeIsNil(contentType string) bool
 }
 
 func getContentfulAPIClient(clientMode ClientMode, clientKey string) (*contentful.Contentful, error) {
+	var c *contentful.Contentful
 	switch clientMode {
 	case ClientModeCDA:
-		return contentful.NewCDA(clientKey), nil
+		c = contentful.NewCDA(clientKey)
 	case ClientModeCPA:
-		return contentful.NewCPA(clientKey), nil
+		c = contentful.NewCPA(clientKey)
 	case ClientModeCMA:
-		return contentful.NewCMA(clientKey), nil
+		c = contentful.NewCMA(clientKey)
 	default:
 		return nil, errors.New("NewContentfulClient: Unknown ClientMode")
 	}
+	return c, nil
 }
 
 func (cc *ContentfulClient) GetSpaceID() string {


### PR DESCRIPTION
### Description

Adds support for Contentful's EU infrastructure region. The region can be specified via the -region flag or the region field in the config YAML. When set, the generated client code calls .SetRegion() on all client modes (CDA, CPA, CMA) as well as the offline client.

### Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [x] ✅ Tests
- [ ] 🔧 Build/CI


## Changes

- Added Region field to Config struct
- Added -region CLI flag to main.go
- GenerateAPI now validates the region via contentful.ParseRegion and passes it to the template
- Template (contentful_vo_lib.gotmpl) conditionally emits .SetRegion() in both getContentfulAPIClient and NewOfflineContentfulClient
- Added generator tests covering EU region, empty region, and invalid region inputs
- Regenerated test/testapi to reflect the refactored getContentfulAPIClient function

### Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.

#### Notes

This PR depends on foomo/contentful#20 which adds the SetRegion/ParseRegion API. Once that PR is merged and a new release is cut, the contentful dependency version in go.mod should be bumped accordingly.